### PR TITLE
Add JP translate

### DIFF
--- a/media/lua/shared/Translate/JP/ContextMenu_JP.txt
+++ b/media/lua/shared/Translate/JP/ContextMenu_JP.txt
@@ -1,0 +1,4 @@
+ContextMenu_JP = {
+	ContextMenu_AddSpearToGrave = "墓穴に槍を追加する"
+	ContextMenu_RemoveSpearFromGrave = "墓穴から槍を取り除く"
+}

--- a/media/lua/shared/Translate/JP/Sandbox_JP.txt
+++ b/media/lua/shared/Translate/JP/Sandbox_JP.txt
@@ -1,0 +1,4 @@
+Sandbox_JP = {
+	Sandbox_SpearTraps_SpearTrapsKillPlayer = "Spear Trapでプレイヤーも死亡する"
+	Sandbox_SpearTraps_SpearTrapsKillPlayer_tooltip = "有効にすると、Spear Trapの上を歩いたときプレイヤーも死亡するようになります"
+}


### PR DESCRIPTION
Thank you for the wonderful mod.
I added a Japanese translation file.

## Detail

* "Spear" is a "槍" in Japanese
* "Grave" is a "墓穴" in Japanese
* "Spear Trap" is not translated because it respects the intent of this mod

## Images

![Context](https://user-images.githubusercontent.com/9024344/140640271-b9c67f66-d012-4373-b059-293f3265310e.png)

![Sandbox](https://user-images.githubusercontent.com/9024344/140640272-6ec82749-0cbc-4a24-b4cf-36452b155632.png)
